### PR TITLE
Fix build status badge

### DIFF
--- a/.github/workflows/master-artifact.yml
+++ b/.github/workflows/master-artifact.yml
@@ -24,7 +24,7 @@ jobs:
         key: ${{ runner.os }}-npm-${{ github.repository }}-${{ github.ref }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
             ${{ runner.os }}-npm-${{ github.repository }}-${{ github.ref }}-
-            ${{ runner.os }}-npm-${{ github.repository }}
+            ${{ runner.os }}-npm-${{ github.repository }}-
 
     - name: Install Dependencies
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-branch-check.yml
+++ b/.github/workflows/pr-branch-check.yml
@@ -24,7 +24,7 @@ jobs:
         key: ${{ runner.os }}-npm-${{ github.repository }}-${{ github.head_ref }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-npm-${{ github.repository }}-${{ github.head_ref }}-
-          ${{ runner.os }}-npm-${{ github.repository }}
+          ${{ runner.os }}-npm-${{ github.repository }}-
 
     - name: Install Dependencies
       if: steps.cache.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Portal LB UI
-![](https://github.com/joekaram/portal-lb-ui/workflows/.github/workflows/master-artifact.yml/badge.svg)
+![](https://github.com/joekaram/portal-lb-ui/workflows/Master%20branch%20check%20and%20artifact%20generation/badge.svg)
 
 Portal LB UI is the user interface which contains all services provided by the Lebanese government.
 


### PR DESCRIPTION
We were using the link for a file path but it won't work because the workflow has a name.

Fixes #9 